### PR TITLE
Grant full access to Skype Message for plugins

### DIFF
--- a/Plugins/HiPlugin.py
+++ b/Plugins/HiPlugin.py
@@ -10,13 +10,13 @@ class HiPlugin(PluginTemplate):
         PluginTemplate.__init__(self, config)
         self.requests = ["^\s*hello\s*$"]
 
-    def plugin_process_request(self, incoming):
+    def plugin_process_request(self, skypeMessage):
         """
         It doesn't override template version
         """
-        return PluginTemplate.plugin_process_request(self, incoming)
+        return PluginTemplate.plugin_process_request(self, skypeMessage)
 
-    def process(self, incoming):
+    def process(self, skypeMessage):
         return "hello"
 
     def check_plugin_config(self):

--- a/Plugins/template.py
+++ b/Plugins/template.py
@@ -17,19 +17,24 @@ class PluginTemplate:
         self.name = config['name']
         self.requests = []
 
-    def plugin_process_request(self, incoming):
+    def plugin_process_request(self, skypeMessage):
         """
         This method runs match against self.request list of regexps
         and returns check status and calls self.process as message
+
+        :param skypeMessage: instance of Skype4Py.Chat.ChatMessage
+
         """
         for rq in self.requests:
-            if re.match(rq, incoming, re.IGNORECASE):
-                return {'status': True, 'message': self.process(incoming)}
+            if re.match(rq, skypeMessage.Body, re.IGNORECASE):
+                return {'status': True, 'message': self.process(skypeMessage)}
         return {'status': False, 'message': 'None'}
 
-    def process(self, incoming):
+    def process(self, skypeMessage):
         """
         This method does all the things. It's not a must to return anything, but usually it's expected
+
+        :param skypeMessage: instance of Skype4Py.Chat.ChatMessage
         """
         return None
 

--- a/skypebot.py
+++ b/skypebot.py
@@ -19,7 +19,7 @@ class SkypeBot:
         print("INCOMING> %s" % msg.Body)
         if status == Skype4Py.cmsReceived:
             for plugin in self.plugins:
-                r = plugin.plugin_process_request(msg.Body)
+                r = plugin.plugin_process_request(msg)
                 if r['status']:
                     msg.Chat.SendMessage(r['message'])
 


### PR DESCRIPTION
Now Plugins receive `Skype4Py.Chat.ChatMessage` instance instead of its body. 
