### PR TITLE
[EnvPlugin] Fix a fix for bug #26 (add correct spacing and foreach replace)

### DIFF
--- a/plugins/EnvPlugin.py
+++ b/plugins/EnvPlugin.py
@@ -110,7 +110,7 @@ class EnvPlugin(PluginTemplate):
         for method in self.methods:
             response = method(message, tag, is_personal)
             if not response is None:
-                return response.replace('/', ' /', 1)
+                return response.replace('/', '/ ')
 
     def help_match(self, message, tag=None, is_personal=False):
         if re.match('^\s*\?env\s+help*$', message.Body, re.IGNORECASE):


### PR DESCRIPTION
This ought to be fixed even in 2.0.0, but I made a mistake: spacing was **before** /, not after. Really stupid one.

Expected behaviour is:
`?env take /leave` -> `?env take / leave`